### PR TITLE
Implement a "startIndex" in `Buffer.indexOf()`

### DIFF
--- a/bufferjs/indexOf.js
+++ b/bufferjs/indexOf.js
@@ -5,9 +5,11 @@
    * A naiive 'Buffer.indexOf' function. Requires both the
    * needle and haystack to be Buffer instances.
    */
-  function indexOf(haystack, needle) {
+  function indexOf(haystack, needle, i) {
     if (!Buffer.isBuffer(needle)) needle = new Buffer(needle);
-    for (var i=0, l=haystack.length-needle.length+1; i<l; i++) {
+    if (typeof i === 'undefined') i = 0;
+    var l = haystack.length - needle.length + 1;
+    while (i<l) {
       var good = true;
       for (var j=0, n=needle.length; j<n; j++) {
         if (haystack[i+j] !== needle[j]) {
@@ -16,12 +18,13 @@
         }
       }
       if (good) return i;
+      i++;
     }
     return -1;
   }
   Buffer.indexOf = indexOf;
-  Buffer.prototype.indexOf = function(needle) {
-    return Buffer.indexOf(this, needle);
+  Buffer.prototype.indexOf = function(needle, i) {
+    return Buffer.indexOf(this, needle, i);
   }
 
 })();

--- a/examples/indexOf-test.js
+++ b/examples/indexOf-test.js
@@ -26,8 +26,21 @@
     assert.equal(haystack.indexOf('should not be found'), -1);
   }
 
+  // Test starting from a specified index
+  function testFromSpecifiedIndex() {
+    var haystack = new Buffer('abracadabra')
+      , needle = new Buffer('a');
+
+    assert.equal(haystack.indexOf(needle), 0);
+    assert.equal(Buffer.indexOf(haystack, needle, 1), 3);
+    assert.equal(haystack.indexOf(needle, 4), 5);
+    assert.equal(Buffer.indexOf(haystack, needle, 6), 7);
+    assert.equal(haystack.indexOf(needle, 8), 10);
+  }
+
   test1();
   test2();
+  testFromSpecifiedIndex();
 
   console.log("Done. `indexOf` tests passed!");
 }());


### PR DESCRIPTION
The JS version of `Array#indexOf()` allows for an optional "startIndex" as a final parameter. And I needed it in my recent project using this function. I just realized that I forgot to update the README with updated API, perhaps you could get around to it. Cheers!
