### PR TITLE
fix: replace get method with index

### DIFF
--- a/bufferjs/indexOf.js
+++ b/bufferjs/indexOf.js
@@ -13,7 +13,7 @@
     while (i<l) {
       var good = true;
       for (var j=0, n=needle.length; j<n; j++) {
-        if (haystack.get(i+j) !== needle.get(j)) {
+        if (haystack[i+j] !== needle[j]) {
           good = false;
           break;
         }


### PR DESCRIPTION
`.get()` was deprecated in Node 4 and [removed](https://github.com/nodejs/node/commit/101bca988c) in Node 6.