### PR TITLE
Use array index instead of Buffer.get

### DIFF
--- a/bufferjs/indexOf.js
+++ b/bufferjs/indexOf.js
@@ -13,7 +13,7 @@
     while (i<l) {
       var good = true;
       for (var j=0, n=needle.length; j<n; j++) {
-        if (haystack.get(i+j) !== needle.get(j)) {
+        if (haystack[i+j] !== needle[j]) {
           good = false;
           break;
         }

--- a/bufferjs/package.json
+++ b/bufferjs/package.json
@@ -9,7 +9,7 @@
                       "Justin Freitag @justinfreitag"
                     ],
   "dependencies"  : {},
-  "version"       : "2.0.0",
+  "version"       : "2.0.1",
   "main"          : "./index",
   "engines"       : {
                       "node" : ">=0.2.0"


### PR DESCRIPTION
`Buffer.get` was deprecated in 2013 ([source](https://github.com/nodejs/node/issues/4587)) and removed entirely in Node 6 ([source](https://github.com/nodejs/node/wiki/Breaking-changes-between-v5-and-v6#buffer)).

Due to the removal of `Buffer.get` this module fails catastrophically in environments running Node 6.  This impacts me because many modules depend on `bufferjs` (notably[`node-slug`](https://github.com/dodo/node-slug)).


